### PR TITLE
Fix RSS links

### DIFF
--- a/src/stories/actions/index.go
+++ b/src/stories/actions/index.go
@@ -177,7 +177,7 @@ func setStoriesMetadata(view *view.Renderer, request *http.Request) {
 		q = "?" + q
 	}
 
-	url := fmt.Sprintf("http://%s%s.xml%s", request.Host, p, q)
+	url := fmt.Sprintf("/%s.xml%s", p, q)
 	view.AddKey("meta_rss", url)
 
 }


### PR DESCRIPTION
The link currently points to http://:4000/index.xml in production.

I've just removed the host and protocol, so it should default to https, like the rest of the site. And the browser will fill the host name, and port if required.

Honestly I've not tested it, as I don't have a db set up. But I think it should work...